### PR TITLE
Added Timeout delay for canvas resize

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
     <button
       type="button"
       class="overlay"
-      id="show-settings"
+      id="btn-show-settings"
       title="Show settings"
     >
       <svg

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -22,18 +22,17 @@ h3 {
   margin-top: 0;
 }
 
-#app,
-#Display {
+#app {
   height: 100%;
   width: 100%;
 }
 
-#DisplayRenderer {
-  image-rendering: -moz-crisp-edges;
-  image-rendering: -webkit-crisp-edges;
-  image-rendering: pixelated;
+canvas {
   image-rendering: crisp-edges;
+  image-rendering: pixelated;
+}
 
+#DisplayRenderer {
   cursor: grab;
 }
 

--- a/public/styles/overlay.scss
+++ b/public/styles/overlay.scss
@@ -7,7 +7,7 @@
   display: none;
 }
 
-#show-settings {
+#btn-show-settings {
   right: 5pt;
 
   background-color: #222222;
@@ -28,12 +28,13 @@
     height: 1.3em;
   }
 
+  outline: none;
   border: none;
   border-radius: 5pt;
   cursor: pointer;
 }
 
-#show-settings:hover {
+#btn-show-settings:hover {
   background-color: whitesmoke;
 
   svg {
@@ -41,7 +42,7 @@
   }
 }
 
-#show-settings:active {
+#btn-show-settings:active {
   background-color: #161616;
   svg {
     color: white;

--- a/src/Engine/Application.ts
+++ b/src/Engine/Application.ts
@@ -30,12 +30,23 @@ export abstract class Application {
   constructor(parent?: HTMLDivElement) {
     this.display = new Display(parent)
     this.time = new Time()
+
+    addEventListener('resize', this.onResize.bind(this))
+  }
+
+  private onResize() {
+    this.stop()
+    if (this.resizeTimeout) clearTimeout(this.resizeTimeout)
+    this.resizeTimeout = setTimeout(() => {
+      if (this.started) this.run()
+    }, this.TIMEOUT_DELAY)
   }
 
   /**
    * Start the Application's main loop
    */
   start(): Application {
+    this.started = true
     this.run()
     return this
   }
@@ -69,8 +80,12 @@ export abstract class Application {
 
   private static instance: Application
   private animationID: number = -1
+  private started: boolean = false
 
   private time: Time
+
+  private TIMEOUT_DELAY: number = 100 // ms
+  private resizeTimeout!: ReturnType<typeof setTimeout>
 
   /**
    * Application main loop
@@ -80,7 +95,7 @@ export abstract class Application {
 
     this.update(this.time)
 
-    this.display.resize()
+    this.display.update(this.time)
     this.render(this.time)
 
     this.animationID = requestAnimationFrame(this.run.bind(this))

--- a/src/Engine/Display.ts
+++ b/src/Engine/Display.ts
@@ -1,3 +1,4 @@
+import { Time } from './Time'
 import { clamp } from 'Engine/Math'
 
 type ContextMode = '2d' | 'webgl' | 'webgl2'
@@ -10,6 +11,8 @@ export class Display {
   canvas: HTMLCanvasElement
 
   private resolution: number = 1.0
+
+  canResize: boolean = true
 
   /**
    * Create display area.
@@ -32,6 +35,10 @@ export class Display {
     this.parent.appendChild(this.canvas)
 
     this.setFill()
+    this.resize()
+  }
+
+  update(time: Time): void {
     this.resize()
   }
 
@@ -139,6 +146,13 @@ export class Display {
 
   getContext(mode: ContextMode) {
     return this.canvas.getContext(mode)
+  }
+
+  getWebGLContext(): WebGLRenderingContext {
+    const context = this.canvas.getContext('webgl')
+    if (!context) throw new Error("Error can't get WebGL context")
+
+    return context as WebGLRenderingContext
   }
 }
 

--- a/src/Sandbox/MandelbrotProps.ts
+++ b/src/Sandbox/MandelbrotProps.ts
@@ -43,15 +43,15 @@ export class MandelbrotProps {
       '#settings'
     ) as HTMLDivElement
     ;(document.querySelector(
-      '#show-settings'
+      '#btn-show-settings'
     ) as HTMLButtonElement).addEventListener('click', this.onClick.bind(this))
 
     this.resolution_scale_input = document.querySelector(
       '#resolution-scale'
     ) as HTMLInputElement
     this.resolution_scale_input.addEventListener(
-      'input',
-      this.onInput.bind(this)
+      'change',
+      this.onChange.bind(this)
     )
   }
 
@@ -160,7 +160,7 @@ export class MandelbrotProps {
     this.isVisisble = !this.isVisisble
   }
 
-  private onInput(event: Event) {
+  private onChange(event: Event) {
     this.resolution = parseFloat(this.resolution_scale_input.value)
   }
 }

--- a/src/Sandbox/Sandbox.ts
+++ b/src/Sandbox/Sandbox.ts
@@ -46,6 +46,7 @@ export class Sandbox extends Application {
 
   constructor(parent: HTMLDivElement) {
     super(parent)
+
     this.input = new Input()
 
     this.mandelbrotProp = new MandelbrotProps()
@@ -56,7 +57,7 @@ export class Sandbox extends Application {
     this.input.registerTouchEvents(this.display.canvas)
     this.input.registerMouseEvents(this.display.canvas)
 
-    this.gl = this.display.getContext('webgl') as WebGLRenderingContext
+    this.gl = this.display.getWebGLContext()
     this.gl.clearColor(0.0, 195 / 255, 255 / 255, 1.0)
 
     this.shader = new Shader(this.gl, VS_Source, Mandelbrot_Source)


### PR DESCRIPTION
Changes resolution scale event from input to change
This is to reduced canvas resize time.

There's a memory leak on safari that happens when the canvas size is changed too fast.